### PR TITLE
feat: add in and not in membership operators

### DIFF
--- a/core/src/parser/operation.rs
+++ b/core/src/parser/operation.rs
@@ -98,8 +98,24 @@ fn other_operator(i: Span) -> Result {
 }
 
 #[tracable_parser]
+fn membership_operator(i: Span) -> Result {
+  map(
+    alt((tag_no_case("in"), tag_no_case("not in"))),
+    move |span: Span| {
+      let op = if span.fragment().to_lowercase() == "in" {
+        Operator::In
+      } else {
+        Operator::NotIn
+      };
+      Node::new(Token::Operator(op), &span)
+    },
+  )(i)
+}
+
+
+#[tracable_parser]
 pub(super) fn binary_operator(i: Span) -> Result {
-  alt((other_operator, arithmetic_operator, comparison_operator, logic_operator))(i)
+  alt((other_operator, membership_operator, arithmetic_operator, comparison_operator, logic_operator))(i)
 }
 
 pub(super) fn unary_operation(i: Span) -> Result {
@@ -263,6 +279,10 @@ mod test {
           case("[1, 2, 3] -- [1, 2, 3]", node!(binary_op!(list!(number!(1), number!(2), number!(3)), "--", list!(number!(1), number!(2), number!(3))))),
           case("add(1, 2) |> add(3)", node!(binary_op!(function!("add", none, number!(1), number!(2)), "|>", function!("add", none, number!(3))))),
           case("[1,2,3] |> sum()", node!(binary_op!(list!(number!(1), number!(2), number!(3)), "|>", function!("sum")))),
+          case("1 in [1,2,3]", node!(binary_op!(number!(1), "in", list!(number!(1), number!(2), number!(3))))),
+          case("1 in foo()", node!(binary_op!(number!(1), "in", function!("foo")))),
+          case("1 not in [1,2,3]", node!(binary_op!(number!(1), "not in", list!(number!(1), number!(2), number!(3))))),
+          case("1 not in foo()", node!(binary_op!(number!(1), "not in", function!("foo")))),
     )]
   fn test_binary_op(input: &'static str, expected: Node, info: TracableInfo) -> Result {
     let span = Span::new_extra(input, info);

--- a/core/src/parser/tokens.rs
+++ b/core/src/parser/tokens.rs
@@ -111,6 +111,10 @@ pub enum Operator {
   GreaterEqual,
   LessEqual,
 
+  // Membership
+  In,
+  NotIn,
+
   // Postfix
   Elipsis,
   AttrAccess,
@@ -150,6 +154,10 @@ impl fmt::Display for Operator {
       Less => "<",
       GreaterEqual => ">=",
       LessEqual => "<=",
+
+      // Membership
+      In => "in",
+      NotIn => "not_in",
 
       // Postfix
       Elipsis => "...",
@@ -192,6 +200,10 @@ impl TryFrom<&str> for Operator {
       "<" => Ok(Operator::Less),
       ">=" => Ok(Operator::GreaterEqual),
       "<=" => Ok(Operator::LessEqual),
+
+      // Membership
+      "in" => Ok(Operator::In),
+      "not in" => Ok(Operator::NotIn),
 
       // Postfix
       "..." => Ok(Operator::Elipsis),


### PR DESCRIPTION
### Motivation

1. Add `in` membership operator e.g. `1 in [1, 2, 3]`
2. Add `not in` membership operator e.g. `1 not in [2, 3]`

### Solution

- Add additional parser for in and not in - `fn membership_operator`

### Open questions

<!--
(optional) Any open questions or feedback on design desired?
-->

### Checklist

- [x] I've confirmed that my PR passes all linting checks
- [x] I've included test cases
- [ ] I've updated the documentation
- [x] I've add `reviewers` where systems they are responsible for is impacted
