### PR TITLE
build: update nom-tracable in core to match cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,7 +180,7 @@ dependencies = [
  "anyhow",
  "clap 3.2.23",
  "core",
- "nom-tracable 0.8.0",
+ "nom-tracable",
  "serde_json",
  "vergen 6.0.2",
 ]
@@ -201,7 +201,7 @@ version = "0.0.33"
 dependencies = [
  "criterion",
  "nom 6.2.1",
- "nom-tracable 0.7.0",
+ "nom-tracable",
  "nom_locate 3.0.2",
  "paste",
  "rstest",
@@ -662,7 +662,6 @@ checksum = "9c5c51b9083a3c620fa67a2a635d1ce7d95b897e957d6b28ff9a5da960a103a6"
 dependencies = [
  "bitvec",
  "funty",
- "lexical-core",
  "memchr",
  "version_check",
 ]
@@ -680,36 +679,14 @@ dependencies = [
 
 [[package]]
 name = "nom-tracable"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "128b58b88f084359e18858edde832830041e0a561d23bb214e656e00972de316"
-dependencies = [
- "nom 6.2.1",
- "nom-tracable-macros 0.7.0",
- "nom_locate 1.0.0",
- "nom_locate 3.0.2",
-]
-
-[[package]]
-name = "nom-tracable"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02e0d5ea9205a12f87381f7449d43a9ff1dd888af72ef01a858ecccd6d4182de"
 dependencies = [
  "nom 7.1.0",
- "nom-tracable-macros 0.8.0",
+ "nom-tracable-macros",
  "nom_locate 1.0.0",
  "nom_locate 4.0.0",
-]
-
-[[package]]
-name = "nom-tracable-macros"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8416fc5553b00d217b0381929fbce7368935d609afdee46c844e09f962b379e6"
-dependencies = [
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -28,7 +28,7 @@ trace = ["nom-tracable/trace"]
 [dependencies]
 nom = { version = "6.2.1", default_features = false, features = ["std"] }
 nom_locate = "3.0.2"
-nom-tracable = "0.7.0"
+nom-tracable = "0.8.0"
 paste = "1.0.6"
 thiserror = "1.0.30"
 serde_with = "1.11.0"


### PR DESCRIPTION
### Motivation

Bump `nom-tracable` to `0.8.0` to match `cli` crate.

### Solution

Update `cargo.toml` and `cargo.lock` to bump `nom-tracable` to `0.8.0` to match `cli` crate.

### Open questions

<!--
(optional) Any open questions or feedback on design desired?
-->

### Checklist

- [ ] I've confirmed that my PR passes all linting checks
- [ ] I've included test cases
- [ ] I've updated the documentation
- [ ] I've add `reviewers` where systems they are responsible for is impacted
